### PR TITLE
Move to spark 2.2.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,11 +1,11 @@
 FROM java:openjdk-8-jdk
 
-ENV spark_ver 2.1.0
+ENV spark_ver 2.2.0
 
 # Get Spark from US Apache mirror.
 RUN mkdir -p /opt && \
     cd /opt && \
-    curl http://www.us.apache.org/dist/spark/spark-${spark_ver}/spark-${spark_ver}-bin-hadoop2.6.tgz | \
+    curl http://www.us.apache.org/dist/spark/spark-${spark_ver}/spark-${spark_ver}-bin-hadoop2.7.tgz | \
         tar -zx && \
     ln -s spark-${spark_ver}-bin-hadoop2.6 spark && \
     echo Spark ${spark_ver} installed in /opt

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ RUN mkdir -p /opt && \
     cd /opt && \
     curl http://www.us.apache.org/dist/spark/spark-${spark_ver}/spark-${spark_ver}-bin-hadoop2.7.tgz | \
         tar -zx && \
-    ln -s spark-${spark_ver}-bin-hadoop2.6 spark && \
+    ln -s spark-${spark_ver}-bin-hadoop2.7 spark && \
     echo Spark ${spark_ver} installed in /opt
 
 

--- a/spark-master-service.yaml
+++ b/spark-master-service.yaml
@@ -15,4 +15,5 @@ spec:
     targetPort: 7077
   selector:
     name: spark-master
+  type: LoadBalancer
 

--- a/spark-master.yaml
+++ b/spark-master.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name : spark-master
-        image: spark-2.1.0-bin-hadoop2.6 
+        image: quay.io/coffeepac/kubernetes-spark:2.2.0
         imagePullPolicy: "IfNotPresent"
         name: spark-master
         ports:

--- a/spark-master.yaml
+++ b/spark-master.yaml
@@ -14,7 +14,7 @@ spec:
       containers:
       - name : spark-master
         image: quay.io/coffeepac/kubernetes-spark:2.2.0
-        imagePullPolicy: "IfNotPresent"
+        imagePullPolicy: "Always"
         name: spark-master
         ports:
         - containerPort: 7077
@@ -24,5 +24,5 @@ spec:
          - "-c"
          - "--"
         args :
-         - './start-master.sh ; sleep infinity'
+         - '/start-master.sh ; sleep infinity'
          

--- a/spark-worker-resource.yaml
+++ b/spark-worker-resource.yaml
@@ -12,7 +12,7 @@ spec:
         name: spark-worker
     spec:
       containers:
-      - image: spark-2.1.0-bin-hadoop2.6 
+      - image: quay.io/coffeepac/kubernetes-spark:2.2.0 
         imagePullPolicy : "IfNotPresent"
         name: spark-worker
         ports:

--- a/spark-worker-resource.yaml
+++ b/spark-worker-resource.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - image: quay.io/coffeepac/kubernetes-spark:2.2.0 
-        imagePullPolicy : "IfNotPresent"
+        imagePullPolicy : "Always"
         name: spark-worker
         ports:
         - containerPort: 7078

--- a/spark-worker.yaml
+++ b/spark-worker.yaml
@@ -5,14 +5,14 @@ metadata:
     name: spark-worker
   name: spark-worker
 spec:
-  replicas: 1
+  replicas: 3
   template:
     metadata:
       labels:
         name: spark-worker
     spec:
       containers:
-      - image: spark-2.1.0-bin-hadoop2.6 
+      - image: quay.io/coffeepac/kubernetes-spark:2.2.0 
         imagePullPolicy : "IfNotPresent"
         name: spark-worker
         ports:

--- a/spark-worker.yaml
+++ b/spark-worker.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - image: quay.io/coffeepac/kubernetes-spark:2.2.0 
-        imagePullPolicy : "IfNotPresent"
+        imagePullPolicy : "Always"
         name: spark-worker
         ports:
         - containerPort: 7078
@@ -23,4 +23,4 @@ spec:
          - "-c"
          - "--"
         args :
-         - './start-worker.sh ; sleep infinity'
+         - '/start-worker.sh ; sleep infinity'


### PR DESCRIPTION
Includes updates for moving to spark 2.2.0, hadoop 2.7 and having a hosted docker image in quay.